### PR TITLE
Make update/resume methods optional, update to match documentation

### DIFF
--- a/Noble.lua
+++ b/Noble.lua
@@ -369,12 +369,12 @@ end
 
 function playdate.gameWillPause()
 	if (currentScene ~= nil) then
-		currentScene:gameWillPause()
+		currentScene:pause()
 	end
 end
 
 function playdate.gameWillResume()
 	if (currentScene ~= nil) then
-		currentScene:gameWillResume()
+		currentScene:resume()
 	end
 end


### PR DESCRIPTION
The documentation currently specifies to use `:pause()` and `:resume()` in `NobleScene` subclasses to handle pause/resume logic (i.e. opening and closing the system menu). However, the current version expects the standard method names `gameWillPause` and `gameWillResume`.

Going on the assumption that the documentation describes the intended behaviour, this PR changes the method names to match. I've tested in my own codebase and all seems well. 

I've also noticed that the game will crash if these methods are not included. Since the documentation seems to indicate they are optional (correctly, in my opinion), I've also taken a crack at updating the engine to silently handle if they're missing. I should note that I am far from a Lua wizard, so this may not be an optimal approach.