### PR TITLE
Subtract horizontal padding when drawing a centered menu

### DIFF
--- a/modules/Noble.Menu.lua
+++ b/modules/Noble.Menu.lua
@@ -484,7 +484,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	-- 	Graphics.setImageDrawMode(self.fillMode)
 	-- 	local xAdjustment = 0
 	-- 	if (self.alignment == Noble.Text.ALIGN_CENTER) then
-	-- 		xAdjustment = self.width/2
+	-- 		xAdjustment = self.width/2 - self.horizontalPadding/2
 	-- 	elseif (self.alignment == Noble.Text.ALIGN_RIGHT) then
 	-- 		xAdjustment = self.width - self.horizontalPadding
 	-- 	end
@@ -495,7 +495,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 		Graphics.setImageDrawMode(self.fillMode)
 		local xAdjustment = self.selectedOutlineThickness
 		if (self.alignment == Noble.Text.ALIGN_CENTER) then
-			xAdjustment = self.width/2
+			xAdjustment = self.width/2 - self.horizontalPadding/2
 		elseif (self.alignment == Noble.Text.ALIGN_RIGHT) then
 			xAdjustment = self.width - self.horizontalPadding - self.selectedOutlineThickness
 		end
@@ -513,8 +513,8 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	-- 	local xAdjustmentText = 0
 	-- 	local xAdjustmentRect = 0
 	-- 	if (self.alignment == Noble.Text.ALIGN_CENTER) then
-	-- 		xAdjustmentText = self.width/2
-	-- 		xAdjustmentRect = self.width/2 - self.itemWidths[self.itemNames[__itemIndex]]/2
+	-- 		xAdjustmentText = self.width/2 - self.horizontalPadding/2
+	--		xAdjustmentRect = self.width/2 - self.itemWidths[self.itemNames[__itemIndex]]/2 - self.horizontalPadding/2
 	-- 	elseif (self.alignment == Noble.Text.ALIGN_RIGHT) then
 	-- 		xAdjustmentText = self.width - self.horizontalPadding
 	-- 		xAdjustmentRect = self.width - self.itemWidths[self.itemNames[__itemIndex]] - self.horizontalPadding
@@ -532,8 +532,8 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 		local xAdjustmentText = self.selectedOutlineThickness
 		local xAdjustmentRect = self.selectedOutlineThickness
 		if (self.alignment == Noble.Text.ALIGN_CENTER) then
-			xAdjustmentText = self.width/2
-			xAdjustmentRect = self.width/2 - self.itemWidths[self.itemNames[__itemIndex]]/2
+			xAdjustmentText = self.width/2 - self.horizontalPadding/2
+			xAdjustmentRect = self.width/2 - self.itemWidths[self.itemNames[__itemIndex]]/2 - self.horizontalPadding/2
 		elseif (self.alignment == Noble.Text.ALIGN_RIGHT) then
 			xAdjustmentText = self.width - self.horizontalPadding - self.selectedOutlineThickness
 			xAdjustmentRect = self.width - self.itemWidths[self.itemNames[__itemIndex]] - self.horizontalPadding - self.selectedOutlineThickness


### PR DESCRIPTION
When attempting to draw a centered menu, the engine currently doesn't take into account horizontal padding. This results in the menu still being pushed slightly too far to the right. This PR subtracts half the horizontal padding from the `xAdjustment` calculation done in `drawItem` and `drawSelectedItem`. This seems to address the layout bug.

Menu setup:
```
mainMenu = Noble.Menu.new(
		true, -- Activate upon creation
		Noble.Text.ALIGN_CENTER, -- Text alignment of menu items
		true, -- Use localization keys, rather than display names
		Graphics.kColorBlack, -- Menu item text color
		16, -- Cell padding for menu items
		nil, -- Horizontal padding for menu items
		nil, -- Margin between menu items
		nil, -- Font
		nil, -- Corner radius for menu items
		nil -- Outline thickness for selected items
	)
```

Menu drawing:

```
mainMenu:draw(
		200,
		100
	)
```

Current result:

<img width="579" alt="Screen Shot 2021-05-04 at 2 16 45 PM" src="https://user-images.githubusercontent.com/36786/117050706-aa523500-ace3-11eb-862b-1ac57fcf13ad.png">

Updated result, taking horizontal padding into account:

<img width="579" alt="Screen Shot 2021-05-04 at 2 19 24 PM" src="https://user-images.githubusercontent.com/36786/117050762-bccc6e80-ace3-11eb-9e0b-f3285e33df64.png">
