### PR TITLE
Optimize setBackgroundDrawingCallback

### DIFF
--- a/Noble.lua
+++ b/Noble.lua
@@ -87,10 +87,10 @@ function Noble.new(StartingScene, __transitionDuration, __transitionType, __enab
 	-- Screen drawing: see the Playdate SDK for details on these methods.
 	Graphics.sprite.setAlwaysRedraw(true)
 	Graphics.sprite.setBackgroundDrawingCallback(
-		function ()
+		function (x, y, width, height)
 			if (currentScene ~= nil) then
 				 -- Each scene has its own method for this. We only want to run one at a time.
-				currentScene:drawBackground()
+				currentScene:drawBackground(x, y, width, height)
 			end
 		end
 	)

--- a/modules/NobleScene.lua
+++ b/modules/NobleScene.lua
@@ -165,16 +165,31 @@ end
 --
 function NobleScene:update() end
 
---- Implement this function to draw background visual elements in your scene. This runs every frame.
+--- Implement this function to draw background visual elements in your scene.
+--- This runs everytime the engine need to redraw a background area.
+--- Default behavior : fillRect area with self.backgroundColor defined.
+--- Put after NobleEngine initialisation Graphics.sprite.setAlwaysRedraw(false) to benefit optimised partial redraw.
 --
 -- @usage
---	function YourSceneName:drawBackground()
---		YourSceneName.super.drawBackground(self)
+--	function YourSceneName:drawBackground(x, y, width, height)
+--		YourSceneName.super.drawBackground(self) -- optional, if you need the default behavior and redraw above backgroundColor
 --		--[Your code here]--
 --	end
 --
-function NobleScene:drawBackground()
-	Graphics.clear(self.backgroundColor)
+function NobleScene:drawBackground(x, y, width, height)
+	local color <const> = Graphics.getColor()
+	local color_type <const> = type(color)
+
+	Graphics.setColor(self.backgroundColor)
+	Graphics.fillRect(x, y, width, height)
+
+	-- avoid side effects by reset the color used before function call
+	-- take care of setPattern usage
+	if color_type == 'number' then
+		Graphics.setColor(color)
+	elseif color_type == 'table' then
+		Graphics.setPattern(color)
+	end
 end
 
 -- This is an internal read-only value used by Noble Engine. It's not useful to you. ;-)

--- a/modules/NobleScene.lua
+++ b/modules/NobleScene.lua
@@ -166,25 +166,31 @@ end
 function NobleScene:update() end
 
 --- Implement this function to draw background visual elements in your scene.
---- This runs everytime the engine need to redraw a background area.
---- Default behavior : fillRect area with self.backgroundColor defined.
---- Put after NobleEngine initialisation Graphics.sprite.setAlwaysRedraw(false) to benefit optimised partial redraw.
+--- This runs when the engine need to redraw a background area.
+--- By default it runs every frame and fills the background with self.backgroundColor. All arguments are optional.
+--- Use `Graphics.sprite.setAlwaysRedraw(false)` after `Noble.new()` to optimize partial redraw.
 --
 -- @usage
---	function YourSceneName:drawBackground(x, y, width, height)
---		YourSceneName.super.drawBackground(self) -- optional, if you need the default behavior and redraw above backgroundColor
+--	function YourSceneName:drawBackground(__x, __y, __width, __height)
+--		YourSceneName.super.drawBackground(self) -- optional, invokes default behavior.
 --		--[Your code here]--
 --	end
 --
-function NobleScene:drawBackground(x, y, width, height)
+function NobleScene:drawBackground(__x, __y, __width, __height)
+	__x = __x or 0
+	__y = __y or 0
+	__width = __width or Display.getWidth()
+	__height = __height or Display.getHeight()
+
+	 -- Cache the currently set color/pattern.
 	local color <const> = Graphics.getColor()
 	local color_type <const> = type(color)
 
+	-- Draw background.
 	Graphics.setColor(self.backgroundColor)
-	Graphics.fillRect(x, y, width, height)
+	Graphics.fillRect(__x, __y, __width, __height)
 
-	-- avoid side effects by reset the color used before function call
-	-- take care of setPattern usage
+	-- Reset color/pattern from cache.
 	if color_type == 'number' then
 		Graphics.setColor(color)
 	elseif color_type == 'table' then


### PR DESCRIPTION
take care of partial redraw by passing area to NobleScene:drawBackground callback
Complete documentation associated to this optimisation

https://github.com/NobleRobot/NobleEngine/issues/14

---

I put some code for Friendly DX, "hidden" setColor can be hard to detect and debug, but maybe it's better to warn in documentation the setColor usage, and simplify the code without get current collor to reset it after the fillRect.

I let you decide