### PR TITLE
Change SceneTemplate to mostly use a local

### DIFF
--- a/modules/NobleScene.lua
+++ b/modules/NobleScene.lua
@@ -7,6 +7,7 @@
 -- @usage
 --	YourSceneName = {}
 --	class("YourSceneName").extends(NobleScene)
+--	local scene = YourSceneName
 --
 -- @classmod NobleScene
 --
@@ -35,30 +36,14 @@ NobleScene.backgroundColor = Graphics.kColorWhite
 --
 -- @usage
 --	YourSceneName.inputHandler = {
---		AButtonDown = function() end,	-- Fires once when button is pressed down.
---		AButtonHold = function() end,	-- Fires each frame while a button is held (Noble Engine implementation).
---		AButtonHeld = function() end,	-- Fires once after button is held for 1 second (available for A and B).
---		AButtonUp = function() end,		-- Fires once when button is released.
---		BButtonDown = function() end,
---		BButtonHold = function() end,
---		BButtonHeld = function() end,
---		BButtonUp = function() end,
---		downButtonDown = function() end,
---		downButtonHold = function() end,
---		downButtonUp = function() end,
---		leftButtonDown = function() end,
---		leftButtonHold = function() end,
---		leftButtonUp = function() end,
---		rightButtonDown = function() end,
---		rightButtonHold = function() end,
---		rightButtonUp = function() end,
---		upButtonDown = function() end,
---		upButtonHold = function() end
---		upButtonUp = function() end,
---
---		cranked = function(change, acceleratedChange) end,	-- See Playdate SDK.
---		crankDocked = function() end,						-- Noble Engine implementation.
---		crankUndocked = function() end,						-- Noble Engine implementation.
+--		AButtonDown = function()
+--			// Your code here
+--		end,
+--		AButtonHold = function()
+--			// Your code here
+--		end,
+--		-- ...
+--		-- ...
 --	}
 --	-- OR...
 --	-- Use a non-scene-specific inputHandler, defined elsewhere.

--- a/templates/SceneTemplate.lua
+++ b/templates/SceneTemplate.lua
@@ -2,79 +2,80 @@
 -- SceneTemplate.lua
 --
 -- Use this as a starting point for your game's scenes. Copy this file to your root "scenes" directory,
--- rename it as you like, and then replace all instances of "SceneTemplate" with your scene's name.
+-- rename it as you like.
 --
 
 SceneTemplate = {}
 class("SceneTemplate").extends(NobleScene)
+local S = SceneTemplate
 
 -- It is recommended that you declare, but don't yet define, your scene-specific varibles and methods here. Use "local" where possible.
 --
 -- local variable1 = nil
--- SceneTemplate.variable2 = nil
+-- S.variable2 = nil
 -- ...
 --
 
-SceneTemplate.backgroundColor = Graphics.kColorWhite		-- This is the background color of this scene.
+S.backgroundColor = Graphics.kColorWhite		-- This is the background color of this scene.
 
 -- This runs when your scene's object is created, which is the first thing that happens when transitining away from another scene.
-function SceneTemplate:init()
-	SceneTemplate.super.init(self)
+function S:init()
+	S.super.init(self)
 
 	-- variable1 = 100
-	-- SceneTemplate.variable2 = "string"
+	-- S.variable2 = "string"
 	-- ...
 
 	-- Your code here
 end
 
 -- When transitioning from another scene, this runs as soon as this scene needs to be visible (this moment depends on which transition type is used).
-function SceneTemplate:enter()
-	SceneTemplate.super.enter(self)
+function S:enter()
+	S.super.enter(self)
 	-- Your code here
 end
 
 -- This runs once a transition from another scene is complete.
-function SceneTemplate:start()
-	SceneTemplate.super.start(self)
+function S:start()
+	S.super.start(self)
 	-- Your code here
 end
 
 -- This runs once per frame.
-function SceneTemplate:update()
-	SceneTemplate.super.update(self)
+function S:update()
+	S.super.update(self)
 	-- Your code here
 end
 
 -- This runs once per frame, and is meant for drawing code.
-function SceneTemplate:drawBackground()
-	SceneTemplate.super.drawBackground(self)
+function S:drawBackground()
+	S.super.drawBackground(self)
 	-- Your code here
 end
 
 -- This runs as as soon as a transition to another scene begins.
-function SceneTemplate:exit()
-	SceneTemplate.super.exit(self)
+function S:exit()
+	S.super.exit(self)
 	-- Your code here
 end
 
 -- This runs once a transition to another scene completes.
-function SceneTemplate:finish()
-	SceneTemplate.super.finish(self)
+function S:finish()
+	S.super.finish(self)
 	-- Your code here
 end
 
-function SceneTemplate:pause()
-	SceneTemplate.super.pause(self)
+function S:pause()
+	S.super.pause(self)
 	-- Your code here
 end
-function SceneTemplate:resume()
-	SceneTemplate.super.resume(self)
+function S:resume()
+	S.super.resume(self)
 	-- Your code here
 end
 
 -- You can define this here, or within your scene's init() function.
-SceneTemplate.inputHandler = {
+S.inputHandler = {
 
 	-- A button
 	--

--- a/templates/SceneTemplate.lua
+++ b/templates/SceneTemplate.lua
@@ -1,81 +1,97 @@
 --
 -- SceneTemplate.lua
 --
--- Use this as a starting point for your game's scenes. Copy this file to your root "scenes" directory,
--- rename it as you like.
+-- Use this as a starting point for your game's scenes.
+-- Copy this file to your root "scenes" directory,
+-- and rename it.
 --
+
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-- !!! Rename "SceneTemplate" to your scene's name in these first three lines. !!!
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 SceneTemplate = {}
 class("SceneTemplate").extends(NobleScene)
-local S = SceneTemplate
+local scene = SceneTemplate
 
--- It is recommended that you declare, but don't yet define, your scene-specific varibles and methods here. Use "local" where possible.
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+-- It is recommended that you declare, but don't yet define,
+-- your scene-specific varibles and methods here. Use "local" where possible.
 --
--- local variable1 = nil
--- S.variable2 = nil
+-- local variable1 = nil	-- local variable
+-- scene.variable2 = nil	-- Scene variable.
+--							   When accessed outside this file use `SceneTemplate.variable2`.
 -- ...
 --
 
-S.backgroundColor = Graphics.kColorWhite		-- This is the background color of this scene.
+-- This is the background color of this scene.
+scene.backgroundColor = Graphics.kColorWhite
 
--- This runs when your scene's object is created, which is the first thing that happens when transitining away from another scene.
-function S:init()
-	S.super.init(self)
+-- This runs when your scene's object is created, which is the
+-- first thing that happens when transitining away from another scene.
+function scene:init()
+	scene.super.init(self)
 
 	-- variable1 = 100
-	-- S.variable2 = "string"
+	-- SceneTemplate.variable2 = "string"
 	-- ...
 
 	-- Your code here
 end
 
--- When transitioning from another scene, this runs as soon as this scene needs to be visible (this moment depends on which transition type is used).
-function S:enter()
-	S.super.enter(self)
+-- When transitioning from another scene, this runs as soon as this
+-- scene needs to be visible (this moment depends on which transition type is used).
+function scene:enter()
+	scene.super.enter(self)
 	-- Your code here
 end
 
 -- This runs once a transition from another scene is complete.
-function S:start()
-	S.super.start(self)
+function scene:start()
+	scene.super.start(self)
 	-- Your code here
 end
 
 -- This runs once per frame.
-function S:update()
-	S.super.update(self)
+function scene:update()
+	scene.super.update(self)
 	-- Your code here
 end
 
 -- This runs once per frame, and is meant for drawing code.
-function S:drawBackground()
-	S.super.drawBackground(self)
+function scene:drawBackground()
+	scene.super.drawBackground(self)
 	-- Your code here
 end
 
 -- This runs as as soon as a transition to another scene begins.
-function S:exit()
-	S.super.exit(self)
+function scene:exit()
+	scene.super.exit(self)
 	-- Your code here
 end
 
 -- This runs once a transition to another scene completes.
-function S:finish()
-	S.super.finish(self)
+function scene:finish()
+	scene.super.finish(self)
 	-- Your code here
 end
 
-function S:pause()
-	S.super.pause(self)
+function scene:pause()
+	scene.super.pause(self)
 	-- Your code here
 end
-function S:resume()
-	S.super.resume(self)
+function scene:resume()
+	scene.super.resume(self)
 	-- Your code here
 end
 
--- You can define this here, or within your scene's init() function.
-S.inputHandler = {
+-- Define the inputHander for this scene here, or use a previously defined inputHandler.
+
+-- scene.inputHandler = someOtherInputHandler
+-- OR
+scene.inputHandler = {
 
 	-- A button
 	--


### PR DESCRIPTION
There are I think two benefits to doing it this way. First when copying
the template into your own code, you only have to change the name in 3
places vs doing a find and replace. And secondly, after you have a scene
or two in your own code, it makes it a lot easier to copy and paste the
function declaration and call to super from one scene to another with no
changes at all.

This is very subjective so no worries if you don’t like this apporach at all.