### PR TITLE
Pass number of frames a button is being held for to input handler

### DIFF
--- a/modules/Noble.Input.lua
+++ b/modules/Noble.Input.lua
@@ -136,43 +136,43 @@ function Noble.Input.update()
 
 	if (currentHandler.AButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonA)) then
-			if (AButtonHoldBufferCount == buttonHoldBufferAmount) then currentHandler.AButtonHold()		-- Execute!
-			else AButtonHoldBufferCount = AButtonHoldBufferCount + 1 end								-- Wait another frame!
+			if (AButtonHoldBufferCount >= buttonHoldBufferAmount) then currentHandler.AButtonHold(AButtonHoldBufferCount) end		-- Execute!
+			AButtonHoldBufferCount = AButtonHoldBufferCount + 1																																	-- Wait another frame!
 		end
-		if (playdate.buttonJustReleased(playdate.kButtonA)) then AButtonHoldBufferCount = 0 end			-- Reset!
+		if (playdate.buttonJustReleased(playdate.kButtonA)) then AButtonHoldBufferCount = 0 end																-- Reset!
 	end
 	if (currentHandler.BButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonB)) then
-			if (BButtonHoldBufferCount == buttonHoldBufferAmount) then currentHandler.BButtonHold()
-			else BButtonHoldBufferCount = BButtonHoldBufferCount + 1 end
+			if (BButtonHoldBufferCount >= buttonHoldBufferAmount) then currentHandler.BButtonHold(BButtonHoldBufferCount) end
+			BButtonHoldBufferCount = BButtonHoldBufferCount + 1
 		end
 		if (playdate.buttonJustReleased(playdate.kButtonB)) then BButtonHoldBufferCount = 0 end
 	end
 	if (currentHandler.upButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonUp)) then
-			if (upButtonHoldBufferCount == buttonHoldBufferAmount) then currentHandler.upButtonHold()
-			else upButtonHoldBufferCount = upButtonHoldBufferCount + 1 end
+			if (upButtonHoldBufferCount >= buttonHoldBufferAmount) then currentHandler.upButtonHold(upButtonHoldBufferCount) end
+			upButtonHoldBufferCount = upButtonHoldBufferCount + 1
 		end
 		if (playdate.buttonJustReleased(playdate.kButtonUp)) then upButtonHoldBufferCount = 0 end
 	end
 	if (currentHandler.downButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonDown)) then
-			if (downButtonHoldBufferCount == buttonHoldBufferAmount) then currentHandler.downButtonHold()
-			else downButtonHoldBufferCount = downButtonHoldBufferCount + 1 end
+			if (downButtonHoldBufferCount >= buttonHoldBufferAmount) then currentHandler.downButtonHold(downButtonHoldBufferCount) end
+			downButtonHoldBufferCount = downButtonHoldBufferCount + 1
 		end
 		if (playdate.buttonJustReleased(playdate.kButtonDown)) then downButtonHoldBufferCount = 0 end
 	end
 	if (currentHandler.leftButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonLeft)) then
-			if (leftButtonHoldBufferCount == buttonHoldBufferAmount) then currentHandler.leftButtonHold()
-			else leftButtonHoldBufferCount = leftButtonHoldBufferCount + 1 end
+			if (leftButtonHoldBufferCount >= buttonHoldBufferAmount) then currentHandler.leftButtonHold(leftButtonHoldBufferCount) end
+			leftButtonHoldBufferCount = leftButtonHoldBufferCount + 1
 		end
 		if (playdate.buttonJustReleased(playdate.kButtonLeft)) then leftButtonHoldBufferCount = 0 end
 	end
 	if (currentHandler.rightButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonRight)) then
-			if (rightButtonHoldBufferCount == buttonHoldBufferAmount) then currentHandler.rightButtonHold()
-			else rightButtonHoldBufferCount = rightButtonHoldBufferCount + 1 end
+			if (rightButtonHoldBufferCount >= buttonHoldBufferAmount) then currentHandler.rightButtonHold(rightButtonHoldBufferCount) end
+			rightButtonHoldBufferCount = rightButtonHoldBufferCount + 1
 		end
 		if (playdate.buttonJustReleased(playdate.kButtonRight)) then rightButtonHoldBufferCount = 0 end
 	end

--- a/modules/Noble.Input.lua
+++ b/modules/Noble.Input.lua
@@ -137,9 +137,9 @@ function Noble.Input.update()
 	if (currentHandler.AButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonA)) then
 			if (AButtonHoldBufferCount >= buttonHoldBufferAmount) then currentHandler.AButtonHold(AButtonHoldBufferCount) end		-- Execute!
-			AButtonHoldBufferCount = AButtonHoldBufferCount + 1																																	-- Wait another frame!
+			AButtonHoldBufferCount = AButtonHoldBufferCount + 1																		-- Wait another frame!
 		end
-		if (playdate.buttonJustReleased(playdate.kButtonA)) then AButtonHoldBufferCount = 0 end																-- Reset!
+		if (playdate.buttonJustReleased(playdate.kButtonA)) then AButtonHoldBufferCount = 0 end										-- Reset!
 	end
 	if (currentHandler.BButtonHold ~= nil) then
 		if (playdate.buttonIsPressed(playdate.kButtonB)) then


### PR DESCRIPTION
This change allows users to access the number of frames a button has been held down for directly in the `xButtonHold` event handler by adding a parameter to the callback as such:

```lua
MyScene.inputHandler = {
  AButtonHold = function(frames)
    if frames > 150 then
      Noble.Text.draw("Stop holding it for so long!", 0, 0)
    end
  end
}
```
This is useful for adding versatility and multiple usage to input buttons, e.g. the A button could be used for interaction when pressed, but when held for 20 frames it would open a menu for an inventory. This was of course already possible by having a counter incremented everytime the callback is being called, but I thought it was more ergonomic to have this baked in.

The callback will still only be triggered when the number of frames is `>= 3`, under 3 frames not being considered holding.

This is a non-breaking change, people can just ignore the parameter and declare a callback without it if they don't need it.

EDIT. Of course if this is accepted as a change, I'll make sure to update the docs everywhere before it gets merged in