### PR TITLE
Fix inconsistency with the docs

### DIFF
--- a/modules/Noble.GameData.lua
+++ b/modules/Noble.GameData.lua
@@ -85,7 +85,7 @@ function Noble.GameData.setup(__keyValuePairs, __numberOfSlots, __saveToDisk, __
 	numberOfSlots = __numberOfSlots or numberOfSlots
 	numberOfGameDataSlotsAtSetup = numberOfSlots
 	local saveToDisk = __saveToDisk or true
-	local modifyExistingOnKeyChange = __modifyExistingOnKeyChange or false
+	local modifyExistingOnKeyChange = __modifyExistingOnKeyChange or true
 	gameDataDefault = {
 		data = __keyValuePairs,
 		timestamp = playdate.getGMTTime()


### PR DESCRIPTION
The [documentation](https://noblerobot.github.io/NobleEngine/modules/Noble.GameData.html) of the `Noble.GameData.setup` method indicates that the default value for the `__modifyExistingOnKeyChange` parameter is true, when in the code it was actually false.

This tiny fix aligns the library with the documentation, by making the default value true.