### PR TITLE
Added orientation getter and event handler

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: NobleRobot
+#patreon: # Replace with a single Patreon username
+#open_collective: # Replace with a single Open Collective username
+ko_fi: NobleRobot
+#tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+#community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+#liberapay: # Replace with a single Liberapay username
+#issuehunt: # Replace with a single IssueHunt username
+#otechie: # Replace with a single Otechie username
+#lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+#custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
### Orientation Method

This PR adds a `Noble.Input.getOrientation` method to easily query and get the current orientation of the device, which can be any of the four:
- `Noble.Input.ORIENTATION_UP` (the regular upstraight orientation)
- `Noble.Input.ORIENTATION_LEFT` (when the device is tilted 90° to the left, with the crank at the top)
- `Noble.Input.ORIENTATION_RIGHT` (when the device is tilted 90° to the right, with the crank at the bottom)
- `Noble.Input.ORIENTATION_DOWN` (when the device is upside down, with the controls at the top and the screen at the bottom)

The method returns a second member in the tuple (which can be ignored), which is a list where containing the `x`, `y`, and `z` readings of the accelerometer at the moment the method was called.

If the accelerometer is on when the `Noble.Input.getOrientation` method is invoked, everything will function properly.
If the accelerometer is off (as it is by default to save power) the method will return that the orientation is upstraight with a false `{ 6, 6, 6 }` reading indicating that it is a false result.

If you call the method with the `__turnOnAccelerometer` parameter set to `true`, the method will execute properly, turning on the accelerometer if needed (if it is off), and either leaving it on if it was already on, or turning it off if it was off.

---
### Orientation Handler

Additionally, this PR introduces an input handler that can notify a scene of a change in the device orientation. You can listen for this event by adding a callback with the `orientationChanged` key in the `inputHandler` table of the current scene.
The callback optionally has access to the new orientation and to the numeric values, as such :

```lua
function MyScene:init()
  MyScene.super.init(self)
  scene.inputHandler = {
    orientationChanged = function(orientation, values)
      print(orientation) -- orientation corresponds to a value in the Noble.Input.ORIENTATION_XX pseudo-enum
      print(x, values[1], y, values[2], z, values[3]) -- the numeric values
    end
  }
end
```

The accelerometer must be **manually turned on by the developer** (via `playdate.startAccelerometer()`) for this event to be triggered.

---
### Demo

![screenshot_demo](https://user-images.githubusercontent.com/43272781/188175418-0a1f50ff-bc4d-4c0c-a5a3-29ed1a7e7a53.png)

I [put together a little demo **(com.simjnd.AccelerometerTest.pdx, 232 KB)**](https://github.com/NobleRobot/NobleEngine/files/9478796/com.simjnd.AccelerometerTest.pdx.zip) made of a single trivial scene (code below) for you to try out the new features. The toast is triggered via the callback, and the rest of the information displayed is simply obtained via the `getOrientation()` method.

```lua
AccelerometerScene = {}
class("AccelerometerScene").extends(NobleScene)
local scene = AccelerometerScene

local x, y, z
local toastTimer = 0
local newOrientation = Noble.Input.ORIENTATION_UP

function scene:init()
  scene.super.init(self)
  Noble.Text.setFont(Noble.Text.FONT_SMALL)
  scene.inputHandler = {
    AButtonDown = function()
      playdate.startAccelerometer()
    end,
    BButtonDown = function()
      playdate.stopAccelerometer()
    end,
    orientationChanged = function(orientation)
      newOrientation = orientation
      toastTimer = 30
    end
  }
end

function scene:update()
  scene.super.update(self)

  -- Display Accelerometer Data
  if playdate.accelerometerIsRunning() then

    x, y, z = playdate.readAccelerometer()

    -- Display toast indicating the orientation has changed
    if (toastTimer > 0) then
      Graphics.fillRoundRect(90, 36, 220, 16, 3)
      Graphics.setImageDrawMode(Graphics.kDrawModeFillWhite)
      Noble.Text.draw("ORIENTATION CHANGED TO " .. newOrientation, 200, 40, Noble.Text.ALIGN_CENTER)
      Graphics.setImageDrawMode(Graphics.kDrawModeFillBlack)
      toastTimer -= 1
    end

    -- Display Orientation and Numeric readings
    Noble.Text.draw("ORIENTATION", 200, 100, Noble.Text.ALIGN_CENTER)
    Noble.Text.draw(Noble.Input.getOrientation(), 200, 112, Noble.Text.ALIGN_CENTER, false, Noble.Text.FONT_LARGE)
    Noble.Text.draw("X / " .. x, 200, 160, Noble.Text.ALIGN_CENTER)
    Noble.Text.draw("Y / " .. y, 200, 172, Noble.Text.ALIGN_CENTER)
    Noble.Text.draw("Z / " .. z, 200, 184, Noble.Text.ALIGN_CENTER)

  -- Display the "Turn On Accelerometer" screen
  else
    Noble.Text.draw("Press A to start accelerometer", 200, 112, Noble.Text.ALIGN_CENTER, false, Noble.Text.FONT_LARGE)
  end
end
```
