### PR TITLE
Support creation of a NobleSprite with an existing image or animation

### DIFF
--- a/modules/NobleSprite.lua
+++ b/modules/NobleSprite.lua
@@ -17,23 +17,23 @@ class("NobleSprite").extends(Graphics.sprite)
 -- @bool[opt=true] __singleStateLoop If using a single state animation, should it loop?
 --
 -- @usage
---	-- Create a new NobleSprite, using a static image for its view.
---	mySprite = NobleSprite("path/to/image")
+--	-- Provide a spritesheet image file to create a new `Noble.Animation` for a NobleSprite's view.
+--	myNobleSprite = NobleSprite("path/to/spritesheet", true)
 --
 -- @usage
---	-- Create a new NobleSprite, creating a new Noble.Animation for its view.
---	mySprite = NobleSprite("path/to/spritesheet", true)
+--	-- Provide an image file to create a new `Graphics.image` for a NobleSprite's view.
+--	myNobleSprite = NobleSprite("path/to/image")
 --
 -- @usage
---	-- Create a new NobleSprite, using an image (Graphics.image) for its view.
---  local myImage = Graphics.image.new("path/to/image")
---	mySprite = NobleSprite(myImage)
---
--- @usage
---	-- Create a new NobleSprite, using an existing Noble.Animation for its view.
+--	-- Use an existing `Noble.Animation` for a NobleSprite's view.
 -- 	local myAnimation = Noble.Animation.new("path/to/spritesheet")
 --  myAnimation:addState("default", 1, animation.imageTable:getLength(), nil, true)
---	mySprite = NobleSprite(myAnimation)
+--	myNobleSprite = NobleSprite(myAnimation)
+--
+-- @usage
+--	-- Use an existing `Graphics.image` object for a NobleSprite's view.
+--  local myImage = Graphics.image.new("path/to/image")
+--	myNobleSprite = NobleSprite(myImage)
 --
 -- @usage
 --	-- Extending NobleSprite.
@@ -48,45 +48,46 @@ class("NobleSprite").extends(Graphics.sprite)
 --	end
 --
 --	-- MyNobleScene.lua
---	mySprite = MyCustomSprite(100, 100, "Fun!")
+--	myNobleSprite = MyCustomSprite(100, 100, "Fun!")
 --
 -- @see Noble.Animation:addState
+-- @see Noble.Animation.new
 --
-function NobleSprite:init(__view, __animated, __singleState, __singleStateLoop)
+function NobleSprite:init(__view, __viewIsSpritesheet, __singleState, __singleStateLoop)
 	NobleSprite.super.init(self)
 	self.isNobleSprite = true -- This is important so other methods don't confuse this for a playdate.graphics.sprite. DO NOT modify this value at runtime.
 
 	if (__view ~= nil) then
 
-		-- __view is the path to an image or spritesheet
+		-- __view is the path to an image or spritesheet file.
 		if (type(__view) == "string") then
-			self.animated = __animated -- NO NOT modify this value at runtime.
+			self.animated = __viewIsSpritesheet -- NO NOT modify self.animated at runtime.
 
-			if (__animated == true) then
-				-- This sprite uses Noble.Animation for its "view."
-	
+			if (__viewIsSpritesheet == true) then
+				-- Create a new Noble.Animation object.
+
 				--- The animation for this NobleSprite.
 				-- @see Noble.Animation.new
 				self.animation = Noble.Animation.new(__view)
-	
+
 				local singleStateLoop = true
 				if (__singleStateLoop ~= nil) then singleStateLoop = __singleStateLoop end
-	
+
 				if (__singleState == true) then
 					self.animation:addState("default", 1, self.animation.imageTable:getLength(), nil, singleStateLoop)
 				end
-	
+
 			else
-				-- This sprite uses playdate.graphics.image for its "view."
+				-- Create a new Graphics.image object.
 				self:setImage(Graphics.image.new(__view))
 			end
 
-		-- __view is an image (Graphics.image)
+		-- __view is an existing Graphics.image object.
 		elseif (type(__view) == "userdata") then
 			self.animated = false
 			self:setImage(__view)
 
-		-- __view is an animation object
+		-- __view is an existing Noble.Animation object.
 		elseif (type(__view) == "table") then
 			self.animated = true
 			self.animation = __view


### PR DESCRIPTION
Solving #13

---

In addition to creating a `NobleSprite` with a path to an image or spritesheet, this PR adds the possibility of creating a `NobleSprite` by giving supplying the function with:
- An image object (`Graphics.image`)
- An animation object (`Noble.Animation`)

This enables caching an image or spritesheet and then using it to instantiate several `NobleSprite` without loading it from disk everytime. You can now do:

```lua
-- Instantiate sprite with an image
local myImage = Graphics.image.new("path/to/image")
mySprite1 = NobleSprite(myImage)
mySprite2 = NobleSprite(myImage)
```
as well as
```lua
-- Instantiate sprite with an animation
local myAnimation = Noble.Animation.new("path/to/spritesheet")
myAnimation:addState("default", 1, animation.imageTable:getLength(), nil, true)
mySprite1 = NobleSprite(myAnimation)
mySprite2 = NobleSprite(myAnimation)
```
---

I had to rename the `__imageOrSpritesheet` parameter to reflect these changes, and didn't think `__imageOrSpritesheetOrAnimation` was super catchy, so ended up opting for `__view`. The inline documentation has also been updated to detail these new usecases and show usage