### PR TITLE
GameData fix: default value always overrides input

### DIFF
--- a/modules/Noble.GameData.lua
+++ b/modules/Noble.GameData.lua
@@ -84,8 +84,13 @@ function Noble.GameData.setup(__keyValuePairs, __numberOfSlots, __saveToDisk, __
 
 	numberOfSlots = __numberOfSlots or numberOfSlots
 	numberOfGameDataSlotsAtSetup = numberOfSlots
-	local saveToDisk = __saveToDisk or true
-	local modifyExistingOnKeyChange = __modifyExistingOnKeyChange or true
+
+	local saveToDisk = true
+	if __saveToDisk == false then saveToDisk = false end
+	
+	local modifyExistingOnKeyChange = true
+	if __modifyExistingOnKeyChange == false then modifyExistingOnKeyChange = false end
+	
 	gameDataDefault = {
 		data = __keyValuePairs,
 		timestamp = playdate.getGMTTime()


### PR DESCRIPTION
A bug found by NickSr, Gamma and joyrider3774 over on Squad Discord: When using 

```lua
function fn(__x) 
  local x = __x or true
  -- etc
```

the value of x will be always true. This construction is not usable with booleans that default to true in Lua. (I‘ve burnt myself before by this one, too :)) 

