### PR TITLE
Handle optional boolean parameters in Utility fn

### DIFF
--- a/Noble.lua
+++ b/Noble.lua
@@ -81,7 +81,7 @@ function Noble.new(StartingScene, __transitionDuration, __transitionType, __enab
 		return
 	else
 		-- Noble Engine refers to an engine-specific error as a "bonk." We check this before engineInitialized is set to true because we need it to be false.
-		local enableDebugBonkChecking = __enableDebugBonkChecking or false
+		local enableDebugBonkChecking = Utilities.handleOptionalBoolean(__enableDebugBonkChecking, false)
 		if (enableDebugBonkChecking) then Noble.Bonk.enableDebugBonkChecking() end
 
 		engineInitialized = true

--- a/modules/Noble.Animation.lua
+++ b/modules/Noble.Animation.lua
@@ -197,7 +197,7 @@ function Noble.Animation.new(__spritesheet)
 			self.currentName = __animationState.name
 		end
 
-		local continuous = __continuous or false
+		local continuous = Utilities.handleOptionalBoolean(__continuous, false)
 
 		if (continuous) then
 			local localFrame = self.currentFrame - self.current.startFrame

--- a/modules/Noble.GameData.lua
+++ b/modules/Noble.GameData.lua
@@ -85,11 +85,8 @@ function Noble.GameData.setup(__keyValuePairs, __numberOfSlots, __saveToDisk, __
 	numberOfSlots = __numberOfSlots or numberOfSlots
 	numberOfGameDataSlotsAtSetup = numberOfSlots
 
-	local saveToDisk = true
-	if __saveToDisk == false then saveToDisk = false end
-	
-	local modifyExistingOnKeyChange = true
-	if __modifyExistingOnKeyChange == false then modifyExistingOnKeyChange = false end
+	local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
+	local modifyExistingOnKeyChange = Utilities.handleOptionalBoolean(__modifyExistingOnKeyChange, true)
 	
 	gameDataDefault = {
 		data = __keyValuePairs,
@@ -170,9 +167,9 @@ function Noble.GameData.set(__dataItemName, __value, __gameDataSlot, __saveToDis
 	currentSlot = __gameDataSlot or currentSlot
 	if (exists(currentSlot, __dataItemName)) then
 		gameDatas[currentSlot].data[__dataItemName] = __value
-		local setTimestamp = __updateTimestamp or true
+		local setTimestamp = Utilities.handleOptionalBoolean(__updateTimestamp, true)
 		if (setTimestamp) then updateTimestamp(gameDatas[currentSlot]) end
-		local saveToDisk = __saveToDisk or true
+		local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
 		if (saveToDisk) then Noble.GameData.save() end
 	end
 end
@@ -187,9 +184,9 @@ function Noble.GameData.reset(__dataItemName, __gameDataSlot, __saveToDisk, __up
 	currentSlot = __gameDataSlot or currentSlot
 	if (exists(currentSlot, __dataItemName)) then
 		gameDatas[currentSlot].data[__dataItemName] = gameDataDefault.data[__dataItemName]
-		local setTimestamp = __updateTimestamp or true
+		local setTimestamp = Utilities.handleOptionalBoolean(__updateTimestamp, true)
 		if (setTimestamp) then updateTimestamp(gameDatas[currentSlot]) end
-		local saveToDisk = __saveToDisk or true
+		local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
 		if (saveToDisk) then Noble.GameData.save(currentSlot) end
 	end
 end
@@ -204,9 +201,9 @@ function Noble.GameData.resetAll(__gameDataSlot, __saveToDisk, __updateTimestamp
 	for key, _ in pairs(gameDatas[currentSlot].data) do
 		gameDatas[currentSlot].data[key] = gameDataDefault.data[key]
 	end
-	local setTimestamp = __updateTimestamp or true
+	local setTimestamp = Utilities.handleOptionalBoolean(__updateTimestamp, true)
 	if (setTimestamp) then updateTimestamp(gameDatas[currentSlot]) end
-	local saveToDisk = __saveToDisk or true
+	local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
 	if (saveToDisk) then Noble.GameData.save(currentSlot) end
 end
 
@@ -217,7 +214,7 @@ end
 -- @usage Noble.GameData.addSlot(10)
 function Noble.GameData.addSlot(__numberToAdd, __saveToDisk)
 	local numberToAdd = __numberToAdd or 1
-	local saveToDisk = __saveToDisk or true
+	local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
 	if (__numberToAdd < 1) then error ("BONK: Don't use a number smaller than 1, silly.", 2) return end
 	for i = 1, numberToAdd, 1 do
 		local newGameData = table.deepcopy(gameDataDefault)
@@ -244,7 +241,7 @@ function Noble.GameData.deleteSlot(__gameDataSlot, __collapseGameDatas)
 	if (__gameDataSlot == nil) then
 		error("BONK: You must specify a GameData slot to delete.")
 	end
-	local collapseGameDatas = __collapseGameDatas or true
+	local collapseGameDatas = Utilities.handleOptionalBoolean(__collapseGameDatas, true)
 	if (exists(__gameDataSlot)) then
 		if (__gameDataSlot > numberOfGameDataSlotsAtSetup) then
 			-- If this GameData is not one of the default ones from setup(), it is removed from disk.

--- a/modules/Noble.Input.lua
+++ b/modules/Noble.Input.lua
@@ -80,7 +80,7 @@ local cachedInputHandler = nil
 -- @see getHandler
 -- @see clearHandler
 function Noble.Input.setEnabled(__value)
-	local value = __value or true
+	local value = Utilities.handleOptionalBoolean(__value, true)
 	if (value == true) then
 		Noble.Input.setHandler(cachedInputHandler or currentHandler)
 		cachedInputHandler = nil

--- a/modules/Noble.Input.lua
+++ b/modules/Noble.Input.lua
@@ -109,7 +109,7 @@ function Noble.Input.setCrankIndicatorStatus(__active, __evenWhenUndocked)
 		UI.crankIndicator:start()
 	end
 	crankIndicatorActive = __active
-	crankIndicatorForced = __evenWhenUndocked or false
+	crankIndicatorForced = Utilities.handleOptionalBoolean(__evenWhenUndocked, false)
 end
 
 --- Checks whether the system crank indicator status. Returns a tuple.
@@ -147,7 +147,7 @@ local accelerometerValues = nil
 -- @see Noble.Input.ORIENTATION_RIGHT
 function Noble.Input.getOrientation(__getStoredValues)
 
-	local getStoredValues = __getStoredValues or false
+	local getStoredValues = Utilities.handleOptionalBoolean(__getStoredValues, false)
 	if (not getStoredValues) then
 
 		local turnOffAfterUse = false

--- a/modules/Noble.Menu.lua
+++ b/modules/Noble.Menu.lua
@@ -290,7 +290,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 
 	--
 
-	local active = __activate or true
+	local active = Utilities.handleOptionalBoolean(__activate, true)
 	if (active) then
 		menu.currentItemNumber = 1
 		menu.currentItemName = menu.itemNames[1]
@@ -336,7 +336,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	--	end
 	function menu:selectPrevious(__force, __wrapSelection)
 		if (self:isActive() or __force) then
-			local wrapSelection = __wrapSelection or true
+			local wrapSelection = Utilities.handleOptionalBoolean(__wrapSelection, true)
 			self:selectPreviousRow(wrapSelection, false, false)
 			local _, row, _ = self:getSelection()
 			self.currentItemNumber = row
@@ -353,7 +353,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	--	end
 	function menu:selectNext(__force, __wrapSelection)
 		if (self:isActive() or __force) then
-			local wrapSelection = __wrapSelection or true
+			local wrapSelection = Utilities.handleOptionalBoolean(__wrapSelection, true)
 			self:selectNextRow(wrapSelection, false, false)
 			local _, row, _ = self:getSelection()
 			self.currentItemNumber = row

--- a/modules/Noble.Menu.lua
+++ b/modules/Noble.Menu.lua
@@ -48,7 +48,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	menu.alignment = __alignment or Noble.Text.ALIGN_LEFT
 
 	--- @bool[opt=false] _ Indicates whether this menu's item names are treated as localization keys.
-	menu.localized = __localized or false
+	menu.localized = Utilities.handleOptionalBoolean(__localized, false)
 	menu.textHeight = textHeightLocal
 	menu.padding = paddingLocal
 	menu.horizontalPadding = __horizontalPadding or menu.padding
@@ -443,7 +443,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	--	end
 	function menu:setItemDisplayName(__itemName, __displayName, __displayNameIsALocalizationKey)
 		self.displayNames[__itemName] = __displayName
-		self.displayNamesAreLocalized[__itemName] = __displayNameIsALocalizationKey or false
+		self.displayNamesAreLocalized[__itemName] = Utilities.handleOptionalBoolean(__displayNameIsALocalizationKey, false)
 
 		local displayName
 		if (__displayNameIsALocalizationKey == true) then

--- a/modules/Noble.Settings.lua
+++ b/modules/Noble.Settings.lua
@@ -52,8 +52,8 @@ function Noble.Settings.setup(__keyValuePairs, __saveToDisk, __modifyExistingOnK
 		settingsHaveBeenSetup = true
 	end
 
-	local saveToDisk = __saveToDisk or true
-	local modifyExistingOnKeyChange = __modifyExistingOnKeyChange or true
+	local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
+	local modifyExistingOnKeyChange = Utilities.handleOptionalBoolean(__modifyExistingOnKeyChange, true)
 	settingsDefault = __keyValuePairs
 
 	-- Get existing settings from disk, if any.
@@ -102,7 +102,7 @@ end
 function Noble.Settings.set(__settingName, __value, __saveToDisk)
 	if (settingExists(__settingName)) then
 		settings[__settingName] = __value
-		local saveToDisk = __saveToDisk or true
+		local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
 		if (saveToDisk) then Noble.Settings.save() end
 	end
 end
@@ -116,7 +116,7 @@ end
 function Noble.Settings.reset(__settingName, __saveToDisk)
 	if (settingExists(__settingName)) then
 		settings[__settingName] = settingsDefault[__settingName]
-		local saveToDisk = __saveToDisk or true
+		local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
 		if (saveToDisk) then Noble.Settings.save() end
 	end
 end
@@ -138,7 +138,7 @@ end
 -- @see save
 function Noble.Settings.resetAll(__saveToDisk)
 	settings = table.deepcopy(settingsDefault)
-	local saveToDisk = __saveToDisk or true
+	local saveToDisk = Utilities.handleOptionalBoolean(__saveToDisk, true)
 	if (saveToDisk) then Noble.Settings.save() end
 end
 

--- a/modules/Noble.Text.lua
+++ b/modules/Noble.Text.lua
@@ -59,7 +59,7 @@ end
 -- @param[opt=Noble.Text.getCurrentFont()] __font A font to use. If not set, the `currentFont` is used. If set, the `currentFont` is not updated.
 function Noble.Text.draw(__string, __x, __y, __alignment, __localized, __font)
 	local alignment = __alignment or Noble.Text.ALIGN_LEFT
-	local localized = __localized or false
+	local localized = Utilities.handleOptionalBoolean(__localized, false)
 
 	if (__font ~= nil) then Graphics.setFont(__font) end -- Temporary font
 

--- a/utilities/Utilities.lua
+++ b/utilities/Utilities.lua
@@ -22,6 +22,17 @@ function Utilities.endsWith(__string, __ending)
 	return __ending == "" or __string:sub(-#__ending) == __ending
 end
 
+function Utilities.handleOptionalBoolean(__argument, __default)
+	if __argument == nil then
+		return __default
+	elseif __argument == true or __argument == false then
+		return __argument
+	else
+		error("BONK: You shouldn’t pass non-boolean value as a boolean parameter.")
+		return __argument
+	end
+end
+
 Utilities.varName = {}
 setmetatable(
 	Utilities.varName,


### PR DESCRIPTION
This is an extension of the previous PR that should correct all boolean optional parameters in the library.

I added a Utility method handleOptionalBoolean that:

- returns default value if nil is passed (this happens when it’s left out)
- returns boolean value if passed
- bonks if non-boolean value is passed

I used it in all places where `or true` and `or false` is used to evaluate optional parameters. It’s crucial only where true is the default value, but it’s good to prevent mistakes in case the behavior changes.

I did not test this, but let me know if there’s any way I can help with that. (If the best way is just to plug it into some game and try it out, I can surely do that :), but if there’s a better way, I’d rather go with that :))