### PR TITLE
fix utilities.copy

### DIFF
--- a/utilities/Utilities.lua
+++ b/utilities/Utilities.lua
@@ -13,7 +13,7 @@ function Utilities.copy(obj, seen)
 	local s = seen or {}
 	local res = setmetatable({}, getmetatable(obj))
 	s[obj] = res
-	for k, v in pairs(obj) do res[copy(k, s)] = copy(v, s) end
+	for k, v in pairs(obj) do res[Utilities.copy(k, s)] = Utilities.copy(v, s) end
 	return res
 end
 


### PR DESCRIPTION
Had an issue where it wouldn't run because `Load failed: libraries/noble/utilities/Utilities.lua:16: global 'copy' is not callable (a nil value)`. This fixes that.