### PR TITLE
remove alwaysRedraw

### DIFF
--- a/.docs/classes/NobleScene.html
+++ b/.docs/classes/NobleScene.html
@@ -344,7 +344,6 @@ local scene = YourSceneName
 						Implement this function to draw background visual elements in your scene.
  This runs when the engine need to redraw a background area.
  By default it runs every frame and fills the background with self.backgroundColor. All arguments are optional.
- Use <code>Graphics.sprite.setAlwaysRedraw(false)</code> after <code>Noble.new()</code> to optimize partial redraw.
 
 								<h3>Parameters</h3>
 							<ul class="parameters">
@@ -481,4 +480,3 @@ local scene = YourSceneName
 
 </body>
 </html>
-

--- a/.docs/modules/Noble.html
+++ b/.docs/modules/Noble.html
@@ -355,12 +355,6 @@
 														<br/>
 														 Noble Engine-specific errors are called "Bonks." You can set this to true during development in order to check for more of them. However, it uses resources, so you will probably want to turn it off before release.
 													</li>
-													<li><span class="parameter">alwaysRedraw</span>
-															<span class="types"><span class="type">bool</span></span>
-															<span class="default">= <span class="value">true</span> (default)</span>
-														<br/>
-														 This sets the Playdate SDK method <code>playdate.graphics.sprite.setAlwaysRedraw</code>. See the Playdate SDK for details on how this function works, and the reasons you might want to set it as true or false for your project.
-													</li>
 							</ul>
 
 
@@ -439,4 +433,3 @@
 
 </body>
 </html>
-

--- a/Noble.lua
+++ b/Noble.lua
@@ -126,8 +126,7 @@ local defaultConfiguration = {
 	defaultTransitionDuration = 1,
 	defaultTransitionHoldDuration = 0.2,
 	defaultTransitionType = Noble.TransitionType.DIP_TO_BLACK,
-	enableDebugBonkChecking = false,
-	alwaysRedraw = true,
+	enableDebugBonkChecking = false
 }
 local configuration = Utilities.copy(defaultConfiguration)
 
@@ -138,7 +137,6 @@ local configuration = Utilities.copy(defaultConfiguration)
 -- @number[opt=0.2] defaultTransitionHoldDuration When running `Noble.transition` (and using a hold-type transition type) if the scene transition hold duration is unspecified, it will take this long in seconds.
 -- @tparam[opt=Noble.TransitionType.CROSS_DISSOLVE] Noble.TransitionType defaultTransitionType When running `Noble.transition` if the transition type is unspecified, it will use this one.
 -- @bool[opt=false] enableDebugBonkChecking Noble Engine-specific errors are called "Bonks." You can set this to true during development in order to check for more of them. However, it uses resources, so you will probably want to turn it off before release.
--- @bool[opt=true] alwaysRedraw This sets the Playdate SDK method `playdate.graphics.sprite.setAlwaysRedraw`. See the Playdate SDK for details on how this function works, and the reasons you might want to set it as true or false for your project.
 -- @see Noble.getConfig
 -- @see Noble.setConfig
 -- @see Noble.Bonk.startCheckingDebugBonks
@@ -167,10 +165,6 @@ function Noble.setConfig(__configuration)
 	if (__configuration.enableDebugBonkChecking ~= nil) then
 		configuration.enableDebugBonkChecking = __configuration.enableDebugBonkChecking
 		if (configuration.enableDebugBonkChecking == true) then Noble.Bonk.enableDebugBonkChecking() end
-	end
-	if (__configuration.alwaysRedraw ~= nil) then
-		configuration.alwaysRedraw = __configuration.alwaysRedraw
-		Graphics.sprite.setAlwaysRedraw(configuration.alwaysRedraw)
 	end
 
 end

--- a/modules/Noble.Bonk.lua
+++ b/modules/Noble.Bonk.lua
@@ -98,9 +98,6 @@ function Noble.Bonk.checkDebugBonks()
 	if (playdate.gameWillResume ~= debugBonks.resume) then
 		error("BONK: Don't manually define playdate.gameWillResume(). Put resume code in your scenes' resume() methods instead.")
 	end
-	if (Graphics.sprite.getAlwaysRedraw() == false) then
-		error("BONK: Don't use Graphics.sprite.setAlwaysRedraw(false) unless you know what you're doing...")
-	end
 	if (Noble.currentScene.backgroundColor == Graphics.kColorClear) then
 		error("BONK: Don't set a scene's backgroundColor to Graphics.kColorClear, silly.")
 	end

--- a/modules/NobleScene.lua
+++ b/modules/NobleScene.lua
@@ -154,7 +154,6 @@ function NobleScene:update() end
 --- Implement this function to draw background visual elements in your scene.
 --- This runs when the engine need to redraw a background area.
 --- By default it runs every frame and fills the background with self.backgroundColor. All arguments are optional.
---- Use `Graphics.sprite.setAlwaysRedraw(false)` after `Noble.new()` to optimize partial redraw.
 --
 -- @usage
 --	function YourSceneName:drawBackground(__x, __y, __width, __height)


### PR DESCRIPTION
Changing the sprite drawing behavior by default is a common complaint I've seen, so I removed it. If the user wants to change it they can use `playdate.graphics.sprite.setAlwaysRedraw(true)`. 