### PR TITLE
Noble.Animation accepts imagetables as well as imagetable paths

### DIFF
--- a/.docs/modules/Noble.Animation.html
+++ b/.docs/modules/Noble.Animation.html
@@ -96,17 +96,18 @@
 			<dl class="function">
 					<dt>
 						<a name = "Noble.Animation.new"></a>
-						<span class="item-name">Noble.Animation.new(__spritesheet)<span>
+						<span class="item-name">Noble.Animation.new(__view)<span>
 					</dt>
 					<dd>
 						Create a new animation "state machine".  This function is called automatically when creating a new <a href="../classes/NobleSprite.html#">NobleSprite</a>.
 
 								<h3>Parameters</h3>
 							<ul class="parameters">
-													<li><span class="parameter">__spritesheet</span>
+													<li><span class="parameter">__view</span>
 															<span class="types"><span class="type">string</span></span>
 														<br/>
-														 The path to the bitmap spritesheet/imagetable asset. See Playdate SDK docs for imagetable file naming conventions.
+														This can be: the path to a spritesheet image file or an image table object (<code>Graphics.imagetable</code>). See Playdate SDK docs for imagetable file naming conventions.
+
 													</li>
 							</ul>
 
@@ -125,7 +126,7 @@
 							<h3>Usage</h3>
 								<pre class="example"><span class="keyword">local</span> myHero = <span class="function-name">MyHero</span>(<span class="string">"path/to/spritesheet"</span>)</pre>
 								<pre class="example"><span class="comment">-- When extending NobleSprite (recommended), you don't call Noble.Animation.new(),
-</span><span class="comment">-- but you do feed its __spritesheet argument into MySprite.super.init()...
+</span><span class="comment">-- but you do feed its __view argument into MySprite.super.init()...
 </span>MyHero = {}
 <span class="function-name">class</span>(<span class="string">"MyHero"</span>).<span class="function-name">extends</span>(NobleSprite)
 

--- a/modules/Noble.Animation.lua
+++ b/modules/Noble.Animation.lua
@@ -8,13 +8,14 @@ Noble.Animation = {}
 -- @section setup
 
 --- Create a new animation "state machine". This function is called automatically when creating a new `NobleSprite`.
--- @string __spritesheet The path to the bitmap spritesheet/imagetable asset. See Playdate SDK docs for imagetable file naming conventions.
+-- @string __view This can be: the path to a spritesheet image file or an image table object (`Graphics.imagetable`). See Playdate SDK docs for imagetable file naming conventions.
+
 -- @return `animation`, a new animation object.
 -- @usage
 --	local myHero = MyHero("path/to/spritesheet")
 -- @usage
 -- -- When extending NobleSprite (recommended), you don't call Noble.Animation.new(),
--- -- but you do feed its __spritesheet argument into MySprite.super.init()...
+-- -- but you do feed its __view argument into MySprite.super.init()...
 --	MyHero = {}
 --	class("MyHero").extends(NobleSprite)
 --
@@ -48,7 +49,7 @@ Noble.Animation = {}
 --		-- ...
 --	end
 --	@see NobleSprite:init
-function Noble.Animation.new(__spritesheet)
+function Noble.Animation.new(__view)
 
 	local animation = {}
 
@@ -82,7 +83,11 @@ function Noble.Animation.new(__spritesheet)
 
 	--- This animation's spritesheet. You can replace this with another `playdate.graphics.imagetable` object, but generally you would not want to.
 	-- @see new
-	animation.imageTable = Graphics.imagetable.new(__spritesheet)
+	if (type(__view) == "userdata") then
+		animation.imageTable = __view
+	else
+		animation.imageTable = Graphics.imagetable.new(__view)
+	end
 	-- The current count of frame durations. This is used to determine when to advance to the next frame.
 	animation.frameDurationCount = 1
 	-- The previous number of frame durations in the animation


### PR DESCRIPTION
This change allows `Noble.Animation` to accept pre-loaded imagetables, in the same way that `Noble.Sprite` can accept both paths and pre-loaded images.

I wasn't able to get Ldoc to work, so had to edit the documentation by hand. Hope I got it right!