### PR TITLE
Fix uneven animation frame durations in Noble.Animation

### DIFF
--- a/Noble.lua
+++ b/Noble.lua
@@ -274,7 +274,9 @@ end
 function Noble.transitionCompleteHandler()
 	isTransitioning = false				-- Reset
 	currentTransition = nil				-- Clear the transition variable.
-	currentScene:start()				-- The new scene is now active.
+	if (currentScene ~= nil) then
+		currentScene:start()				-- The new scene is now active.
+	end
 end
 
 --- Get the current scene object

--- a/Noble.lua
+++ b/Noble.lua
@@ -264,9 +264,11 @@ function Noble.transitionMidpointHandler()
 		currentScene:finish()
 		currentScene = nil				-- Allows current scene to be garbage collected.
 	end
-	currentScene = queuedScene			-- New scene's update loop begins.
-	queuedScene = nil
-	currentScene:enter()				-- The new scene runs its "hello" code.
+	if (queuedScene ~= nil) then
+		currentScene = queuedScene			-- New scene's update loop begins.
+		queuedScene = nil
+		currentScene:enter()				-- The new scene runs its "hello" code.
+	end
 end
 
 function Noble.transitionCompleteHandler()

--- a/libraries/Sequence.lua
+++ b/libraries/Sequence.lua
@@ -340,7 +340,6 @@ function Sequence:get( time )
 		return 0
 	end
 
-	time = time or self.time
 	if time == nil then
 		time = self.time
 	else

--- a/libraries/Sequence.lua
+++ b/libraries/Sequence.lua
@@ -72,7 +72,7 @@ function Sequence.update( pacing )
 	pacing = pacing or 1
 
 	local currentTime = playdate.getCurrentTimeMilliseconds()
-	local deltaTime = ((currentTime-_previousUpdateTime) / 1000) * pacing
+	local deltaTime = (currentTime-_previousUpdateTime) * pacing
 	_previousUpdateTime = currentTime
 
 	for index = #_runningSequences, 1, -1 do
@@ -146,6 +146,7 @@ function Sequence:to( to, duration, easingFunction, ... )
 	-- default parameters
 	to = to or 0
 	duration = duration or 0.3
+	duration = math.floor(1000*duration)
 	easingFunction = easingFunction or _easings.inOutQuad
 	if type(easingFunction)=="string" then
 		easingFunction = _easings[easingFunction] or _easings.inOutQuad
@@ -223,6 +224,7 @@ function Sequence:sleep( duration )
 	if not self then return end
 
 	duration = duration or 0.5
+	duration = math.floor(1000*duration)
 	if duration==0 then
 		return self
 	end
@@ -247,6 +249,7 @@ function Sequence:callback( fn, timeOffset )
 	if not self then return end
 
 	timeOffset = timeOffset or 0
+	timeOffset = math.floor(1000*timeOffset)
 
 	local lastEasing = self.easings[self.easingCount]
 
@@ -338,6 +341,11 @@ function Sequence:get( time )
 	end
 
 	time = time or self.time
+	if time == nil then
+		time = self.time
+	else
+		time = math.floor(1000*time)
+	end
 
 	-- try to get cached result
 	if self.cachedResultTimestamp==time then
@@ -369,10 +377,11 @@ function Sequence:updateCallbacks( dt )
 		end
 
 		for index, cbObject in pairs(self.callbacks) do
-			if cbObject.timestamp>=clampedStart and cbObject.timestamp<=clampedEnd then
-				if type(cbObject.fn)=="function" then
-					cbObject.fn()
-				end
+			if cbObject.timestamp==clampedStart and clampedStart==0 or
+			   	cbObject.timestamp>clampedStart and cbObject.timestamp<=clampedEnd then
+					if type(cbObject.fn)=="function" then
+						cbObject.fn()
+					end
 			end
 		end
 	end

--- a/libraries/Sequence.lua
+++ b/libraries/Sequence.lua
@@ -79,10 +79,10 @@ function Sequence.update( pacing )
 		local seq = _runningSequences[index]
 
 		if seq.isRunning == true then
-			seq:updateCallbacks( deltaTime )
-
 			seq.time = seq.time + deltaTime
 			seq.cachedResultTimestamp = nil
+			
+			seq:updateCallbacks( deltaTime )
 
 			if seq:isDone() then
 				seq.isRunning = false
@@ -361,6 +361,8 @@ function Sequence:updateCallbacks( dt )
 		return
 	end
 
+	local previousTime = self.time - dt
+	
 	local callTimeRange = function( clampedStart, clampedEnd)
 		if clampedStart>clampedEnd then
 			clampedStart, clampedEnd = clampedEnd, clampedStart
@@ -377,7 +379,7 @@ function Sequence:updateCallbacks( dt )
 
 	-- most straightforward case: no loop
 	if not self.loopType then
-		local clampedTime = self:getClampedTime( self.time )
+		local clampedTime = self:getClampedTime( previousTime )
 		callTimeRange(clampedTime, clampedTime+dt)
 		return
 	end
@@ -390,7 +392,7 @@ function Sequence:updateCallbacks( dt )
 		callTimeRange(0, self.duration)
 	end
 
-	local clampedTime, isForward = self:getClampedTime( self.time )
+	local clampedTime, isForward = self:getClampedTime( previousTime )
 	local endTime = clampedTime
 	if isForward then
 		endTime = endTime + dt

--- a/libraries/Sequence.lua
+++ b/libraries/Sequence.lua
@@ -78,22 +78,35 @@ function Sequence.update( pacing )
 	for index = #_runningSequences, 1, -1 do
 		local seq = _runningSequences[index]
 
-		seq:updateCallbacks( deltaTime )
+		if seq.isRunning == true then
+			seq:updateCallbacks( deltaTime )
 
-		seq.time = seq.time + deltaTime
-		seq.cachedResultTimestamp = nil
+			seq.time = seq.time + deltaTime
+			seq.cachedResultTimestamp = nil
 
-		if seq:isDone() then
+			if seq:isDone() then
+				seq.isRunning = false
+			end
+		end
+
+		if seq.isRunning == false then
 			table.remove(_runningSequences, index)
-			seq.isRunning = false
 		end
 	end
 end
 
 function Sequence.print()
-	print("Sequences running:", #_runningSequences)
-for index, seq in pairs(_runningSequences) do
-		print(" Sequence", index, seq)
+	local count = 0
+	for index, seq in pairs(_runningSequences) do
+		if seq.isRunning then
+			count = count + 1
+		end
+	end
+	print("Sequences running:", count)
+	for index, seq in pairs(_runningSequences) do
+		if seq.isRunning then
+			print(" Sequence", index, seq)
+		end
 	end
 end
 
@@ -435,10 +448,6 @@ function Sequence:addRunning()
 end
 
 function Sequence:removeRunning()
-	local indexInRunningTable = table.indexOfElement(_runningSequences, self)
-	if indexInRunningTable then
-		table.remove(_runningSequences, indexInRunningTable)
-	end
 	self.isRunning = false
 end
 

--- a/modules/Noble.Animation.lua
+++ b/modules/Noble.Animation.lua
@@ -239,12 +239,12 @@ function Noble.Animation.new(__view)
 			if (self.current.next ~= nil) then
 				self.currentFrame = self.current.next.startFrame	-- Set to first frame of next animation.
 				self.frameDurationCount = 1										-- Reset ticks.
-				self.previousFrameDurationCount = self.frameDuration
+				self.previousFrameDurationCount = 1
 				self:setState(self.current.next)					-- Set next animation state.
 			elseif (self.current.loop == true) then
 				self.currentFrame = self.current.startFrame 		-- Loop animation state. (TO-DO: account for continuous somehow?)
 				self.frameDurationCount = 1										-- Reset ticks.
-				self.previousFrameDurationCount = self.frameDuration
+				self.previousFrameDurationCount = 1
 			elseif(__advance) then
 				self.currentFrame = self.currentFrame - 1			-- Undo advance frame because we want to draw the same frame again.
 			end


### PR DESCRIPTION
This changelist addresses an issue in the `Noble.Animation` module where the first frame of an animation was displayed for a longer duration than subsequent frames.

The problem was due to the way `previousFrameDurationCount` was reset on successive loops or transitions. This has been corrected to ensure all frames have the same duration.