### PR TITLE
Fix bug where Menu:activate() does not select

### DIFF
--- a/modules/Noble.Menu.lua
+++ b/modules/Noble.Menu.lua
@@ -308,8 +308,8 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	--	local menu = Noble.Menu.new(false)
 	--	menu:activate()
 	function menu:activate()
-		self:select(self.currentItemNumber)
 		active = true
+		self:select(self.currentItemNumber)
 	end
 	--- Deactivate this menu.
 	-- This deselects all menu items, and disables this menu's @{selectPrevious|selectPrevious}, @{selectNext|selectNext}, and @{click|click} methods.


### PR DESCRIPTION
Fixes [Issue 71](https://github.com/NobleRobot/NobleEngine/issues/71). Because `Menu:select()` requires that the menu `isActive()` (or has been `__forced`), we ensure that this is true in `Menu:activate()`.

With this change, launching the [NobleEngine-ProjectTemplate](https://github.com/NobleRobot/NobleEngine-ProjectTemplate) shows a selection immediately.
![nr-bugfix](https://github.com/NobleRobot/NobleEngine/assets/1574365/ea3c4b08-dcaa-4f01-8cb5-bfd532689c6f)
