### PR TITLE
Fix animation frame duration issue

### DIFF
--- a/modules/Noble.Animation.lua
+++ b/modules/Noble.Animation.lua
@@ -138,7 +138,7 @@ function Noble.Animation.new(__view)
 			self.currentFrame = __startFrame
 			self.current = self[__name]
 			self.currentName = __name
-			self.frameDuration = frameDuration
+			self.current.frameDuration = frameDuration
 		end
 
 	end
@@ -238,13 +238,13 @@ function Noble.Animation.new(__view)
 		elseif(self.currentFrame == self.current.endFrame + 1) then	-- End frame behavior.
 			if (self.current.next ~= nil) then
 				self.currentFrame = self.current.next.startFrame	-- Set to first frame of next animation.
-				self.frameDurationCount = 1										-- Reset ticks.
-				self.previousFrameDurationCount = self.frameDuration
+				self.current.frameDurationCount = 1										-- Reset ticks.
+				self.previousFrameDurationCount = self.current.frameDuration
 				self:setState(self.current.next)					-- Set next animation state.
 			elseif (self.current.loop == true) then
 				self.currentFrame = self.current.startFrame 		-- Loop animation state. (TO-DO: account for continuous somehow?)
-				self.frameDurationCount = 1										-- Reset ticks.
-				self.previousFrameDurationCount = self.frameDuration
+				self.current.frameDurationCount = 1										-- Reset ticks.
+				self.previousFrameDurationCount = self.current.frameDuration
 			elseif(__advance) then
 				self.currentFrame = self.currentFrame - 1			-- Undo advance frame because we want to draw the same frame again.
 			end
@@ -259,8 +259,8 @@ function Noble.Animation.new(__view)
 		self.imageTable:drawImage(self.currentFrame, x, y, self.direction)
 
 		if (__advance == true) then
-			self.frameDurationCount += 1
-			if((self.frameDurationCount - self.previousFrameDurationCount) >= self.current.frameDuration) then
+			self.current.frameDurationCount += 1
+			if((self.current.frameDurationCount - self.previousFrameDurationCount) >= self.current.frameDuration) then
 				self.currentFrame = self.currentFrame + 1
 				self.previousFrameDurationCount += self.current.frameDuration
 			end

--- a/modules/Noble.Animation.lua
+++ b/modules/Noble.Animation.lua
@@ -238,12 +238,12 @@ function Noble.Animation.new(__view)
 		elseif(self.currentFrame == self.current.endFrame + 1) then	-- End frame behavior.
 			if (self.current.next ~= nil) then
 				self.currentFrame = self.current.next.startFrame	-- Set to first frame of next animation.
-				self.current.frameDurationCount = 1										-- Reset ticks.
+				self.frameDurationCount = 1										-- Reset ticks.
 				self.previousFrameDurationCount = self.current.frameDuration
 				self:setState(self.current.next)					-- Set next animation state.
 			elseif (self.current.loop == true) then
 				self.currentFrame = self.current.startFrame 		-- Loop animation state. (TO-DO: account for continuous somehow?)
-				self.current.frameDurationCount = 1										-- Reset ticks.
+				self.frameDurationCount = 1										-- Reset ticks.
 				self.previousFrameDurationCount = self.current.frameDuration
 			elseif(__advance) then
 				self.currentFrame = self.currentFrame - 1			-- Undo advance frame because we want to draw the same frame again.
@@ -259,8 +259,8 @@ function Noble.Animation.new(__view)
 		self.imageTable:drawImage(self.currentFrame, x, y, self.direction)
 
 		if (__advance == true) then
-			self.current.frameDurationCount += 1
-			if((self.current.frameDurationCount - self.previousFrameDurationCount) >= self.current.frameDuration) then
+			self.frameDurationCount += 1
+			if((self.frameDurationCount - self.previousFrameDurationCount) >= self.current.frameDuration) then
 				self.currentFrame = self.currentFrame + 1
 				self.previousFrameDurationCount += self.current.frameDuration
 			end


### PR DESCRIPTION
I've noticed that in my walking animation (a looping 2 frame animation) there's one frame being drawn more than the other. This PR fixes that.

It seems that there were a couple of instances of `self.frameDuration` that should have really been `self.current.frameDuration`

#### Before
![before](https://github.com/NobleRobot/NobleEngine/assets/1364447/fea8d3cf-7163-47eb-b596-10d367961e51)

#### After
![after](https://github.com/NobleRobot/NobleEngine/assets/1364447/a96b8382-2cf8-48b0-a3b4-8b08cdf2f195)
