### PR TITLE
Fix duration failsafe clamping durationEnter twice instead of durationExit

### DIFF
--- a/modules/Noble.Transition.lua
+++ b/modules/Noble.Transition.lua
@@ -59,7 +59,7 @@ function Noble.Transition:init(__duration, __arguments)
 		self.durationEnter = frameDuration + self.holdTime/2 + 0.001
 	end
 	if ((self.durationExit - self.holdTime/2) < frameDuration) then
-		self.durationEnter = frameDuration + self.holdTime/2 + 0.001
+		self.durationExit = frameDuration + self.holdTime/2 + 0.001
 	end
 
 	if (self._type == Noble.Transition.Type.MIX) then


### PR DESCRIPTION
The single-frame duration failsafe added in 7225537 tests `durationExit` but assigns the clamped value to `durationEnter`:

```lua
if ((self.durationExit - self.holdTime/2) < frameDuration) then
	self.durationEnter = frameDuration + self.holdTime/2 + 0.001
end
```

So a too-short `durationExit` is left unclamped, and a valid `durationEnter` gets overwritten. One-word fix: assign to `self.durationExit`.

Noticed while looking into #87 (not necessarily the root cause of that crash, but worth fixing either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
