### PR TITLE
Fix gridview error when removing the last Noble.Menu item

### DIFF
--- a/modules/Noble.Menu.lua
+++ b/modules/Noble.Menu.lua
@@ -277,7 +277,14 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 			end
 		end
 
-		self:setNumberOfRows(#self.itemNames)
+		if (#self.itemNames == 0) then
+			-- The menu is now empty. A gridview section must contain at least one row,
+			-- so we leave the row count alone and clear the current selection instead.
+			self.currentItemNumber = 1
+			self.currentItemName = nil
+		else
+			self:setNumberOfRows(#self.itemNames)
+		end
 
 		-- Update width
 		local width = 0
@@ -474,6 +481,7 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 	--		menu:draw(50, 100)
 	--	end
 	function menu:draw(__x, __y)
+		if (#self.itemNames == 0) then return end
 		local xAdjustment = 0
 		if (self.alignment == Noble.Text.ALIGN_CENTER) then
 			xAdjustment = self.width/2

--- a/modules/Noble.Menu.lua
+++ b/modules/Noble.Menu.lua
@@ -215,6 +215,16 @@ function Noble.Menu.new(__activate, __alignment, __localized, __color, __padding
 
 		self:setNumberOfRows(#self.itemNames)
 
+		-- If there is no current item (i.e. this item was added to an empty menu),
+		-- this item becomes the current one, so that click() works on it.
+		if (self.currentItemName == nil) then
+			self.currentItemNumber = 1
+			self.currentItemName = self.itemNames[1]
+			if (self:isActive()) then
+				self:setSelectedRow(1)
+			end
+		end
+
 	end
 
 	-- Internal method.


### PR DESCRIPTION
Fixes #89.

`Noble.Menu:removeItem()` called `setNumberOfRows()` unconditionally, passing 0 when the menu was emptied, which triggers `ERROR: playdate.ui.gridview sections must contain at least one row` on the console.

Two commits:

1. **`removeItem()`**: the row count is now only updated when at least one item remains. Emptying the menu instead resets the selection state (`currentItemName` is cleared and `currentItemNumber` returns to 1, matching a freshly created menu), and `draw()` early-returns for an empty menu so the retained one-row gridview never draws a phantom cell. Repopulating an emptied menu via `addItem()` resizes the gridview as usual.

2. **`addItem()`**: an item added to an emptied menu is now made the current item. Without this, the first item added back *drew* as selected (the gridview still had a selected row), but `click()` silently did nothing — `clickHandlers[currentItemName]` looked up a nil key — until the player first pressed up or down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
