### PR TITLE
Add Noble.performTransition() to play a transition without changing scenes

### DIFF
--- a/.docs/modules/Noble.html
+++ b/.docs/modules/Noble.html
@@ -31,6 +31,7 @@
 							<li><a href="#setConfig">.setConfig</a></li>
 							<li><a href="#resetConfig">.resetConfig</a></li>
 							<li><a href="#transition">.transition</a></li>
+							<li><a href="#performTransition">.performTransition</a></li>
 							<li><a href="#currentScene">.currentScene</a></li>
 							<li><a href="#currentSceneName">.currentSceneName</a></li>
 							<li><a href="#isTransitioning">.isTransitioning</a></li>

--- a/.docs/modules/Noble.html
+++ b/.docs/modules/Noble.html
@@ -304,6 +304,7 @@
 
 							<h3>See</h3>
 							<ul>
+									<li><a href="../modules/Noble.html#performTransition">Noble.performTransition</a></li>
 									<li><a href="../modules/Noble.html#isTransitioning">Noble.isTransitioning</a></li>
 									<li><a href="../classes/NobleScene.html#">NobleScene</a></li>
 									<li><a href="../modules/Noble.Transition.html#">Noble.Transition</a></li>
@@ -333,6 +334,59 @@
 	{
 		levelName = <span class="string">"Level Two: The Second Level!"</span>
 		levelData = <span class="string">"levels/level2.json"</span>,
+	}
+)</pre>
+
+					</dd>
+					<dt>
+						<a name = "performTransition"></a>
+						<span class="item-name">performTransition([__duration=1.5[, __transition=Noble.Transition.DipToBlack[, __transitionProperties={}]]])<span>
+					</dt>
+					<dd>
+						Play a transition animation without changing scenes (at the end of this frame).
+ The current scene stays loaded and remains the active scene, but user input is disabled until the transition completes. To run code at specific moments during the transition, use the transition's callback properties, such as <code>onMidpoint</code> and <code>onComplete</code>.
+ Additional calls to this method (or to <code>Noble.transition</code>) within the same frame (before the already-called transition begins), will override previous calls. Any calls to this method once a transition begins will be ignored until the transition completes.
+
+								<h3>Parameters</h3>
+							<ul class="parameters">
+													<li><span class="parameter">__duration</span>
+															<span class="types"><span class="type">number</span></span>
+															<span class="default">= <span class="value">1.5</span> (default)</span>
+														<br/>
+														 The length of the transition, in seconds.
+													</li>
+													<li><span class="parameter">__transition</span>
+															<span class="types"><span class="type">Noble.Transition</span></span>
+															<span class="default">= <span class="value">Noble.Transition.DipToBlack</span> (default)</span>
+														<br/>
+														 If a transition duration is set, use this transition type. If not set, it will use the value of <code>configuration.defaultTransition</code>.
+													</li>
+													<li><span class="parameter">__transitionProperties</span>
+															<span class="types"><span class="type">table</span></span>
+															<span class="default">= <span class="value">{}</span> (default)</span>
+														<br/>
+														 A table consisting of properties for this transition. Properties not set here will use values that transition's <code>defaultProperties</code> table.
+													</li>
+							</ul>
+
+
+
+							<h3>See</h3>
+							<ul>
+									<li><a href="../modules/Noble.html#transition">Noble.transition</a></li>
+									<li><a href="../modules/Noble.html#isTransitioning">Noble.isTransitioning</a></li>
+									<li><a href="../modules/Noble.Transition.html#">Noble.Transition</a></li>
+							</ul>
+
+							<h3>Usage</h3>
+								<pre class="example">Noble.<span class="function-name">performTransition</span>(<span class="number">1.5</span>, Noble.Transition.DipToBlack,
+	{
+		holdTime = <span class="number">0.5</span>,
+		onMidpoint = <span class="keyword">function</span>()
+			<span class="comment">-- The screen is fully obscured, so we can modify the
+</span>			<span class="comment">-- current scene without the player seeing it happen.
+</span>			player:moveTo(<span class="number">50</span>, <span class="number">100</span>)
+		<span class="keyword">end</span>
 	}
 )</pre>
 

--- a/Noble.lua
+++ b/Noble.lua
@@ -203,6 +203,7 @@ end
 --
 local currentTransition = nil
 local queuedScene = nil
+local transitionIsSceneless = false
 
 --- Transition to a new scene (at the end of this frame).
 --- This method will create a new scene, mark the previous one for garbage collection, and animate between them.
@@ -238,6 +239,7 @@ local queuedScene = nil
 -- 		levelData = "levels/level2.json",
 -- 	}
 -- )
+-- @see Noble.performTransition
 -- @see Noble.isTransitioning
 -- @see NobleScene
 -- @see Noble.Transition
@@ -254,6 +256,47 @@ function Noble.transition(NewScene, __duration, __transition, __transitionProper
 
 	local sceneProperties = __sceneProperties or {}
 	queuedScene = NewScene(sceneProperties) -- Creates new scene object. Its init() function runs now.
+	transitionIsSceneless = false
+
+	currentTransition = (__transition or configuration.defaultTransition)(
+		__duration or configuration.defaultTransitionDuration,
+		__transitionProperties or {}
+	)
+end
+
+--- Play a transition animation without changing scenes (at the end of this frame).
+--- The current scene stays loaded and remains the active scene, but user input is disabled until the transition completes. To run code at specific moments during the transition, use the transition's callback properties, such as `onMidpoint` and `onComplete`.
+--- Additional calls to this method (or to `Noble.transition`) within the same frame (before the already-called transition begins), will override previous calls. Any calls to this method once a transition begins will be ignored until the transition completes.
+-- @number[opt=1.5] __duration The length of the transition, in seconds.
+-- @tparam[opt=Noble.Transition.DipToBlack] Noble.Transition __transition If a transition duration is set, use this transition type. If not set, it will use the value of `configuration.defaultTransition`.
+-- @tparam[opt={}] table __transitionProperties A table consisting of properties for this transition. Properties not set here will use values that transition's `defaultProperties` table.
+-- @usage
+-- Noble.performTransition(1.5, Noble.Transition.DipToBlack,
+-- 	{
+-- 		holdTime = 0.5,
+-- 		onMidpoint = function()
+-- 			-- The screen is fully obscured, so we can modify the
+-- 			-- current scene without the player seeing it happen.
+-- 			player:moveTo(50, 100)
+-- 		end
+-- 	}
+-- )
+-- @see Noble.transition
+-- @see Noble.isTransitioning
+-- @see Noble.Transition
+function Noble.performTransition(__duration, __transition, __transitionProperties)
+	if (isTransitioning) then
+		-- This bonk no longer throws an error (compared to previous versions of Noble Engine), but maybe it still should?
+		warn("BONK: You can't start a transition in the middle of another transition, silly!")
+		return -- Let's get otta here!
+	elseif (currentTransition ~= nil) then
+		-- Calling this method multiple times between Noble.update() calls is probably not intentional behavior.
+		warn("Soft-BONK: You are queueing multiple transitions within the same frame. Did you mean to do that?")
+		-- We don't return here because maybe the developer *did* intend to override a previous call.
+	end
+
+	queuedScene = nil					-- Discards any scene queued by a same-frame call to Noble.transition().
+	transitionIsSceneless = true
 
 	currentTransition = (__transition or configuration.defaultTransition)(
 		__duration or configuration.defaultTransitionDuration,
@@ -266,13 +309,16 @@ end
 
 function Noble.transitionStartHandler()
 	isTransitioning = true
-	if (currentScene ~= nil) then
+	if (not transitionIsSceneless and currentScene ~= nil) then
 		currentScene:exit()				-- The current scene runs its "goodbye" code. Sprites are taken out of the simulation.
 	end
 	Noble.Input.setHandler(nil)			-- Disable user input.
 end
 
 function Noble.transitionMidpointHandler()
+	if (transitionIsSceneless) then
+		return							-- The current scene isn't going anywhere. Carry on!
+	end
 	if (currentScene ~= nil) then
 		currentScene:finish()
 		currentScene = nil				-- Allows current scene to be garbage collected.
@@ -285,7 +331,15 @@ end
 function Noble.transitionCompleteHandler()
 	isTransitioning = false				-- Reset
 	currentTransition = nil				-- Clear the transition variable.
-	currentScene:start()				-- The new scene is now active.
+	if (transitionIsSceneless) then
+		transitionIsSceneless = false	-- Reset
+		if (currentScene ~= nil) then
+			Noble.Input.setHandler(currentScene.inputHandler)	-- Re-enable user input, without re-running the current scene's start() code.
+		end
+		Graphics.sprite.redrawBackground()
+	else
+		currentScene:start()			-- The new scene is now active.
+	end
 end
 
 --- Get the current scene object

--- a/Noble.lua
+++ b/Noble.lua
@@ -204,6 +204,7 @@ end
 local currentTransition = nil
 local queuedScene = nil
 local transitionIsSceneless = false
+local scenelessTransitionInputHandler = nil
 
 --- Transition to a new scene (at the end of this frame).
 --- This method will create a new scene, mark the previous one for garbage collection, and animate between them.
@@ -309,7 +310,9 @@ end
 
 function Noble.transitionStartHandler()
 	isTransitioning = true
-	if (not transitionIsSceneless and currentScene ~= nil) then
+	if (transitionIsSceneless) then
+		scenelessTransitionInputHandler = Noble.Input.getHandler()	-- Capture the active inputHandler (which may not be the current scene's) so it can be restored when the transition completes.
+	elseif (currentScene ~= nil) then
 		currentScene:exit()				-- The current scene runs its "goodbye" code. Sprites are taken out of the simulation.
 	end
 	Noble.Input.setHandler(nil)			-- Disable user input.
@@ -333,9 +336,8 @@ function Noble.transitionCompleteHandler()
 	currentTransition = nil				-- Clear the transition variable.
 	if (transitionIsSceneless) then
 		transitionIsSceneless = false	-- Reset
-		if (currentScene ~= nil) then
-			Noble.Input.setHandler(currentScene.inputHandler)	-- Re-enable user input, without re-running the current scene's start() code.
-		end
+		Noble.Input.setHandler(scenelessTransitionInputHandler)	-- Restore the inputHandler that was active when the transition started, without re-running the current scene's start() code.
+		scenelessTransitionInputHandler = nil
 		Graphics.sprite.redrawBackground()
 	else
 		currentScene:start()			-- The new scene is now active.

--- a/modules/Noble.Transition.lua
+++ b/modules/Noble.Transition.lua
@@ -95,6 +95,13 @@ function Noble.Transition:init(__duration, __arguments)
 
 	end
 
+	-- Callback properties for this invocation of this transition. When set, these
+	-- shadow the transition's own callback methods (they do not overwrite them).
+	if (__arguments.onStart ~= nil)				then self.onStart = __arguments.onStart end
+	if (__arguments.onMidpoint ~= nil)			then self.onMidpoint = __arguments.onMidpoint end
+	if (__arguments.onHoldTimeElapsed ~= nil)	then self.onHoldTimeElapsed = __arguments.onHoldTimeElapsed end
+	if (__arguments.onComplete ~= nil)			then self.onComplete = __arguments.onComplete end
+
 	self:setProperties(__arguments)
 
 end
@@ -185,15 +192,23 @@ end
 function Noble.Transition:setProperties(__arguments) end
 
 --- *Do not call this directly.* Implement this in a custom transition in order to run custom code when the transition starts. Default transitions in Noble Engine do not use this.
+-- You may also set this as a property (`onStart`) when invoking a transition, in order to run custom code for that invocation only. Callbacks set this way receive the transition object as their first argument.
+-- @see Noble.performTransition
 function Noble.Transition:onStart() end
 
 --- *Do not call this directly.* Implement this in a custom transition in order to run custom code when the transition reaches its midpoint. Default transitions in Noble Engine do not use this.
+-- You may also set this as a property (`onMidpoint`) when invoking a transition, in order to run custom code for that invocation only. Callbacks set this way receive the transition object as their first argument.
+-- @see Noble.performTransition
 function Noble.Transition:onMidpoint() end
 
 --- *Do not call this directly.* Implement this in a custom transition in order to run custom code when the transition's hold time has elapsed. Default transitions in Noble Engine do not use this.
+-- You may also set this as a property (`onHoldTimeElapsed`) when invoking a transition, in order to run custom code for that invocation only. Callbacks set this way receive the transition object as their first argument.
+-- @see Noble.performTransition
 function Noble.Transition:onHoldTimeElapsed() end
 
 --- *Do not call this directly.* Implement this in a custom transition in order to run custom code when the transition completes. Default transitions in Noble Engine do not use this.
+-- You may also set this as a property (`onComplete`) when invoking a transition, in order to run custom code for that invocation only. Callbacks set this way receive the transition object as their first argument.
+-- @see Noble.performTransition
 function Noble.Transition:onComplete() end
 
 --- *Do not call this directly.* Implement this in a custom transition to draw the transition. This runs once per frame while the transition is running. See existing transitions for implementation examples.

--- a/modules/Noble.Transition.lua
+++ b/modules/Noble.Transition.lua
@@ -142,8 +142,8 @@ function Noble.Transition:execute()
 	end
 
 	local onComplete = function()
-		self:onComplete()				-- If this transition has any custom code to run here, run it.
 		Noble.transitionCompleteHandler()
+		self:onComplete()				-- If this transition has any custom code to run here, run it. This runs after the engine's handler (matching onStart/onMidpoint), so a new transition may be started from within this callback.
 	end
 
 	local type = self._type


### PR DESCRIPTION
Closes #82.

Adds `Noble.performTransition(__duration, __transition, __transitionProperties)`: plays a transition animation while the current scene stays loaded and active. The scene's `exit()`, `finish()`, `enter()`, and `start()` methods are not called, and no new scene is created. User input is disabled when the transition starts, and the input handler that was active at that moment is restored when it completes (rather than assuming `currentScene.inputHandler` — games that manage input separately from the scene, a documented `Noble.Input` use case, keep their handler).

Transitions also now accept per-invocation callback properties (`onStart`, `onMidpoint`, `onHoldTimeElapsed`, `onComplete`) in the transition properties table, which shadow the transition's callback methods for that invocation only. This enables the headline use case from #82: dip to black, mutate the current scene at the midpoint while the screen is obscured, then dip back:

```lua
Noble.performTransition(1.5, Noble.Transition.DipToBlack, {
	onMidpoint = function()
		-- rearrange the scene while the screen is black
	end
})
```

One ordering fix that this feature surfaced: the `onComplete` closure in `Noble.Transition:execute()` ran the transition's `onComplete()` callback *before* `Noble.transitionCompleteHandler()`, so `isTransitioning` was still true inside user code — chaining a transition from `onComplete` (the natural use of the new callbacks) hit the "You can't start a transition in the middle of another transition" guard and was silently dropped. The engine handler now runs first, matching the ordering already used by the `onStart` and `onMidpoint` closures.

Existing `Noble.transition()` behavior is unchanged. The generated docs pages for the new API are included (hand-patched HTML — happy to regenerate with LDoc instead if you prefer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
