### PR TITLE
Route gameWillTerminate, deviceWillSleep, deviceWillLock, and deviceDidUnlock to scene methods

### DIFF
--- a/Noble.lua
+++ b/Noble.lua
@@ -386,3 +386,27 @@ function playdate.gameWillResume()
 		currentScene:resume()
 	end
 end
+
+function playdate.gameWillTerminate()
+	if (currentScene ~= nil) then
+		currentScene:gameWillTerminate()
+	end
+end
+
+function playdate.deviceWillSleep()
+	if (currentScene ~= nil) then
+		currentScene:deviceWillSleep()
+	end
+end
+
+function playdate.deviceWillLock()
+	if (currentScene ~= nil) then
+		currentScene:deviceWillLock()
+	end
+end
+
+function playdate.deviceDidUnlock()
+	if (currentScene ~= nil) then
+		currentScene:deviceDidUnlock()
+	end
+end

--- a/modules/Noble.Bonk.lua
+++ b/modules/Noble.Bonk.lua
@@ -21,6 +21,10 @@ function Noble.Bonk.enableDebugBonkChecking()
 			debugBonks.update = playdate.update
 			debugBonks.pause = playdate.gameWillPause
 			debugBonks.resume = playdate.gameWillResume
+			debugBonks.terminate = playdate.gameWillTerminate
+			debugBonks.sleep = playdate.deviceWillSleep
+			debugBonks.lock = playdate.deviceWillLock
+			debugBonks.unlock = playdate.deviceDidUnlock
 			debugBonks.crankDocked = playdate.crankDocked
 			debugBonks.crankUndocked = playdate.crankUndocked
 			bonksAreSetup = true
@@ -97,6 +101,18 @@ function Noble.Bonk.checkDebugBonks()
 	end
 	if (playdate.gameWillResume ~= debugBonks.resume) then
 		error("BONK: Don't manually define playdate.gameWillResume(). Put resume code in your scenes' resume() methods instead.")
+	end
+	if (playdate.gameWillTerminate ~= debugBonks.terminate) then
+		error("BONK: Don't manually define playdate.gameWillTerminate(). Put termination code in your scenes' gameWillTerminate() methods instead.")
+	end
+	if (playdate.deviceWillSleep ~= debugBonks.sleep) then
+		error("BONK: Don't manually define playdate.deviceWillSleep(). Put sleep code in your scenes' deviceWillSleep() methods instead.")
+	end
+	if (playdate.deviceWillLock ~= debugBonks.lock) then
+		error("BONK: Don't manually define playdate.deviceWillLock(). Put lock code in your scenes' deviceWillLock() methods instead.")
+	end
+	if (playdate.deviceDidUnlock ~= debugBonks.unlock) then
+		error("BONK: Don't manually define playdate.deviceDidUnlock(). Put unlock code in your scenes' deviceDidUnlock() methods instead.")
 	end
 	if (Graphics.sprite.getAlwaysRedraw() == false) then
 		error("BONK: Don't use Graphics.sprite.setAlwaysRedraw(false) unless you know what you're doing...")

--- a/modules/NobleScene.lua
+++ b/modules/NobleScene.lua
@@ -240,3 +240,44 @@ function NobleScene:pause() end
 --		--[Your code here]--
 --	end
 function NobleScene:resume() end
+
+--- `gameWillTerminate()` / `deviceWillSleep()` / `deviceWillLock()` / `deviceDidUnlock()`
+--
+-- Implement any of these in your scene if you want something to happen when the system fires the
+-- matching lifecycle event, such as saving game data when the game is about to close, or playing
+-- an exit animation.
+--
+-- <strong>NOTE: The Playdate OS uses a watchdog timer of roughly 10 seconds for `gameWillTerminate()`,
+-- after which your game is force-closed, so keep your termination code brief.</strong> Also note that
+-- SDK timers do not advance while the device is locked or asleep.
+--
+-- @usage
+--	function YourSceneName:gameWillTerminate()
+--		YourSceneName.super.gameWillTerminate(self)
+--		--[Your code here]--
+--	end
+function NobleScene:gameWillTerminate() end
+
+--- <span></span>
+-- @usage
+--	function YourSceneName:deviceWillSleep()
+--		YourSceneName.super.deviceWillSleep(self)
+--		--[Your code here]--
+--	end
+function NobleScene:deviceWillSleep() end
+
+--- <span></span>
+-- @usage
+--	function YourSceneName:deviceWillLock()
+--		YourSceneName.super.deviceWillLock(self)
+--		--[Your code here]--
+--	end
+function NobleScene:deviceWillLock() end
+
+--- <span></span>
+-- @usage
+--	function YourSceneName:deviceDidUnlock()
+--		YourSceneName.super.deviceDidUnlock(self)
+--		--[Your code here]--
+--	end
+function NobleScene:deviceDidUnlock() end


### PR DESCRIPTION
Closes #55.

Routes `playdate.gameWillTerminate()`, `playdate.deviceWillSleep()`, `playdate.deviceWillLock()`, and `playdate.deviceDidUnlock()` to same-named methods on the current scene, mirroring the existing `gameWillPause()`/`gameWillResume()` pattern:

- `Noble.lua` defines the four SDK callbacks and forwards to `Noble.currentScene():<method>()`.
- `NobleScene` gains documented no-op defaults, including a note about the OS's ~10-second watchdog for `gameWillTerminate()`.
- `Noble.Bonk` gains matching debug checks (same as the existing `gameWillPause`/`gameWillResume` checks) so games that define these SDK callbacks manually get a warning instead of silently overriding the engine's routing.

Source LDoc comments are in place; I left the generated `.docs` HTML out of this PR to avoid churn — it'll regenerate on the next docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
